### PR TITLE
More cleanup after repo migration

### DIFF
--- a/.github/workflows/busted.yml
+++ b/.github/workflows/busted.yml
@@ -27,4 +27,8 @@ jobs:
         luarocks install luacov-coveralls
         luarocks install ${{ matrix.penlightSource }}
     - name: Run Busted Tests
-      run: busted -c
+      run: busted -c -v
+    - name: Report Test Coverage
+      if: matrix.luaVersion == '5.3' && matrix.penlightSource == 'penlight' && success()
+      continue-on-error: true
+      run: luacov-coveralls -i cassowary -v -t "${{ secrets.LUACOV_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Busted](https://github.com/sile-typesetter/cassowary.lua/workflows/Busted/badge.svg)](https://github.com/sile-typesetter/cassowary.lua/actions)
 [![Coverage Status](https://coveralls.io/repos/github/sile-typesetter/cassowary.lua/badge.svg?branch=master)](https://coveralls.io/github/sile-typesetter/cassowary.lua?branch=master)
 [![GitHub tag (latest SemVer)](https://img.shields.io/github/v/tag/sile-typesetter/cassowary.lua)](https://github.com/sile-typesetter/cassowary.lua/releases)
-[![LuaRocks](https://img.shields.io/luarocks/v/sile-typesetter/cassowary)](https://luarocks.org/modules/sile-typesetter/cassowary)
+[![LuaRocks](https://img.shields.io/luarocks/v/simoncozens/cassowary)](https://luarocks.org/modules/simoncozens/cassowary)
 
 This is a lua port of the [cassowary](http://constraints.cs.washington.edu/cassowary/)
 constraint solving toolkit. It allows you to use lua to solve algebraic equations and

--- a/cassowary-scm-0.rockspec
+++ b/cassowary-scm-0.rockspec
@@ -2,7 +2,7 @@ package = "Cassowary"
 version = "scm-0"
 
 source = {
-   url = "git://github.com/simoncozens/cassowary.lua",
+   url = "git://github.com/sile-typesetter/cassowary.lua",
 }
 
 description = {
@@ -12,7 +12,7 @@ description = {
       It allows you to use lua to solve algebraic equations and inequalities 
       and find the values of unknown variables which satisfy those inequalities.
    ]],
-   homepage = "https://github.com/simoncozens/cassowary.lua",
+   homepage = "https://github.com/sile-typesetter/cassowary.lua",
    license = "Apache 2"
 }
 


### PR DESCRIPTION
Ooops, Lua Rocks link shouldn't have changed. On the other hand the link inside the rock should!

Making this a draft until I can figure out whats up with coveralls. I think it's not reporting because it doesn't have history to report against any more, but there could be more to it than that.