### PR TITLE
Drop obsolete hack, test latest and most common Penlight versions

### DIFF
--- a/.github/workflows/busted.yml
+++ b/.github/workflows/busted.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         luaVersion: ["5.3", "5.2", "5.1", "luajit", "luajit-openresty"]
-        penlightSource: ["penlight", "https://raw.githubusercontent.com/stevedonovan/Penlight/master/penlight-scm-2.rockspec"]
+        penlightVersion: ["1.7.0", "1.6.0", "1.5.4"]
 
     runs-on: ubuntu-latest
 
@@ -16,7 +16,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@master
     - name: Setup Lua
-      uses: leafo/gh-actions-lua@v2
+      uses: leafo/gh-actions-lua@v5
       with:
         luaVersion: ${{ matrix.luaVersion }}
     - name: Setup Lua Rocks
@@ -25,10 +25,9 @@ jobs:
       run: |
         luarocks install busted
         luarocks install luacov-coveralls
-        luarocks install ${{ matrix.penlightSource }}
+        luarocks install penlight ${{ matrix.penlightVersion }}
     - name: Run Busted Tests
       run: busted -c -v
     - name: Report Test Coverage
-      if: matrix.luaVersion == '5.3' && matrix.penlightSource == 'penlight' && success()
       continue-on-error: true
       run: luacov-coveralls -i cassowary -v -t "${{ secrets.LUACOV_TOKEN }}"


### PR DESCRIPTION
Penlight has a new maintainer and the luarocks releases are up to date with the Github ones, so we don't need that hack. Testing most widely used two versions as before plus the latest release.