### PR TITLE
Refresh CI jobs

### DIFF
--- a/.github/workflows/busted.yml
+++ b/.github/workflows/busted.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         luaVersion: [ "5.4", "5.3", "5.2", "5.1", "luajit", "luajit-openresty" ]
-        penlightVersion: [ "1.9.2", "1.8.0", "1.6.0", "1.5.4" ]
+        penlightVersion: [ "1.12.0", "1.9.2", "1.8.0", "1.6.0", "1.5.4" ]
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout

--- a/.github/workflows/busted.yml
+++ b/.github/workflows/busted.yml
@@ -1,6 +1,6 @@
 name: Busted
 
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 jobs:
 
@@ -8,14 +8,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        luaVersion: ["5.4", "5.3", "5.2", "5.1", "luajit", "luajit-openresty"]
-        penlightVersion: ["1.9.2", "1.8.0", "1.6.0", "1.5.4"]
+        luaVersion: [ "5.4", "5.3", "5.2", "5.1", "luajit", "luajit-openresty" ]
+        penlightVersion: [ "1.9.2", "1.8.0", "1.6.0", "1.5.4" ]
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup ‘lua’
-      uses: leafo/gh-actions-lua@v8
+      uses: leafo/gh-actions-lua@v9
       with:
         luaVersion: ${{ matrix.luaVersion }}
     - name: Setup ‘luarocks’

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,71 +1,34 @@
 name: Deploy
 
-on:
-  push:
-    paths:
-      - rockspecs/*.rockspec
+on: [ push, workflow_dispatch ]
 
 jobs:
 
   affected:
-    runs-on: ubuntu-20.04
-    outputs:
-      rockspecs: '["${{ steps.changed-files.outputs.all_modified_files }}"]'
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-    - id: changed-files
-      uses: tj-actions/changed-files@v1.0.2
-      with:
-        files: rockspecs/*.rockspec
-        separator: '", "'
+    uses: lunarmodules/.github/.github/workflows/list_affected_rockspecs.yml@main
 
   build:
     needs: affected
     if: ${{ needs.affected.outputs.rockspecs }}
-    strategy:
-      fail-fast: false
-      matrix:
-        # Upstream Issue: https://github.com/leafo/gh-actions-luarocks/issues/8
-        luaVersion: ["5.4", "5.3", "5.2", "5.1"] #, "luajit", "luajit-openresty"]
-        # Upstream Issue: https://github.com/leafo/gh-actions-luarocks/issues/8
-        luarocksVersion: ["3.1.3"] # , "2.4.2"]
-        rockspec: ${{ fromJSON(needs.affected.outputs.rockspecs) }}
-    runs-on: ubuntu-20.04
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Setup ‘lua’
-      uses: leafo/gh-actions-lua@v8
-      with:
-        luaVersion: ${{ matrix.luaVersion }}
-    - name: Setup ‘luarocks’
-      uses: leafo/gh-actions-luarocks@v4
-      with:
-        luarocksVersion: ${{ matrix.luarocksVersion }}
-    - name: Confirm rockspec builds
-      run: |
-        luarocks --lua-version ${{ matrix.luaVersion }} --local build -- ${{ matrix.rockspec }}
+    uses: lunarmodules/.github/.github/workflows/test_build_rock.yml@main
+    with:
+      rockspecs: ${{ needs.affected.outputs.rockspecs }}
 
   upload:
-    needs: [affected, build]
-    if: ${{ needs.affected.outputs.rockspecs && github.ref == 'refs/heads/master' && github.repository == 'sile-typesetter/cassowary.lua' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        rockspec: ${{ fromJSON(needs.affected.outputs.rockspecs) }}
-    runs-on: ubuntu-20.04
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Setup ‘lua’
-      uses: leafo/gh-actions-lua@v8
-    - name: Setup ‘luarocks’
-      uses: leafo/gh-actions-luarocks@v4
-    - name: Setup dependencies
-      run: |
-        luarocks install dkjson
-    - run: |
-        luarocks upload --force --api-key ${{ secrets.LUAROCKS_APIKEY }} -- ${{ matrix.rockspec }}
+    needs: [ affected, build ]
+    # Only run upload if:
+    # 1. Some rockspecs were changed — this implies the commit changing the rockspec is the same one that gets tagged
+    # 2. The current commit is either tagged or on the default branch (the workflow will upload dev/scm rockspecs any
+    #    time they are touched, tagged ones whenever the edited rockspec and tag match)
+    # 3. We are on the canonical repository (no uploads from forks)
+    if: >-
+      ${{
+        github.repository == 'sile-typesetter/cassowary.lua' &&
+        ( github.ref_name == 'master' || startsWith(github.ref, 'refs/tags/') ) &&
+        needs.affected.outputs.rockspecs
+      }}
+    uses: lunarmodules/.github/.github/workflows/upload_to_luarocks.yml@main
+    with:
+      rockspecs: ${{ needs.affected.outputs.rockspecs }}
+    secrets:
+      apikey: ${{ secrets.LUAROCKS_APIKEY }}

--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -1,6 +1,6 @@
 name: Luacheck
 
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 jobs:
 

--- a/.github/workflows/luarocks.yml
+++ b/.github/workflows/luarocks.yml
@@ -1,21 +1,25 @@
 name: Luarocks
 
-on: [push, pull_request]
+on: [ push, pull_request ]
 
 jobs:
 
-  luarocks:
+  # More extensive testing gets done when a rockspec is touched, this just
+  # makes sure expected files didn't shift without updating the rockspec
+  build:
+    name: Test bulid on Linux
     runs-on: ubuntu-20.04
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-    - name: Setup ‘lua’
-      uses: leafo/gh-actions-lua@v8
-    - name: Setup ‘luarocks’
-      uses: leafo/gh-actions-luarocks@v4
-    - name: Luarocks lint
-      run: |
-        luarocks --local lint -- cassowary-scm-0.rockspec
-    - name: Luarocks make
-      run: |
-        luarocks --local make -- cassowary-scm-0.rockspec
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup ‘lua’
+        uses: leafo/gh-actions-lua@v9
+      - name: Setup ‘luarocks’
+        uses: leafo/gh-actions-luarocks@v4
+      - name: Luarocks lint
+        run: |
+          luarocks lint -- cassowary-scm-0.rockspec
+      - name: Luarocks make
+        run: |
+          luarocks make -- cassowary-scm-0.rockspec


### PR DESCRIPTION
- ci: Reuse deploy workflow from lunarmodules
- ci: Cleanup and normalize workflow systax
- ci: Add latest Penlight to testing matrix, drop unnecessary versions
