### PR TITLE
Fix a few bits leftover from stdlib monkey patching

### DIFF
--- a/.github/workflows/busted.yml
+++ b/.github/workflows/busted.yml
@@ -9,7 +9,7 @@ jobs:
       fail-fast: false
       matrix:
         luaVersion: [ "5.4", "5.3", "5.2", "5.1", "luajit", "luajit-openresty" ]
-        penlightVersion: [ "1.12.0", "1.9.2", "1.8.0", "1.6.0", "1.5.4" ]
+        penlightVersion: [ "1.12.0", "1.9.2", "1.5.4" ]
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout

--- a/cassowary-scm-0.rockspec
+++ b/cassowary-scm-0.rockspec
@@ -20,7 +20,7 @@ description = {
 
 dependencies = {
    "lua >= 5.1",
-   "penlight"
+   "penlight >= 1.5.4"
 }
 
 build = {

--- a/cassowary/init.lua
+++ b/cassowary/init.lua
@@ -485,7 +485,7 @@ cassowary.Expression = class({
     local sort_hashcodes = function (a, b) return a.hashcode < b.hashcode end
     for clv, coeff in tablex.sort(self.terms, sort_hashcodes) do
       if needsplus then rv = rv .. " + " end
-      rv = rv .. coeff .. "*" .. clv.value
+      rv = rv .. coeff .. "*" .. tostring(clv.value)
       needsplus = true
     end
     return rv
@@ -508,7 +508,9 @@ cassowary.Expression = class({
   end
 })
 
-local _constraintStringify = function (self) return tostring(self.strength) .. " {" .. tostring(self.weight) .. "} (" .. tostring(self.expression) .. ")" end
+local _constraintStringify = function (self)
+  return tostring(self.strength) .. " {" .. tostring(self.weight) .. "} (" .. tostring(self.expression) .. ")"
+end
 
 cassowary.AbstractConstraint = class({
   isEditConstraint = false,
@@ -896,7 +898,7 @@ cassowary.SimplexSolver = subclass(cassowary.Tableau, {
   end,
 
   resolveArray = function (self, newEditConstants)
-    cassowary:traceFnEnterPrint("resolveArray: "..newEditConstants)
+    cassowary:traceFnEnterPrint("resolveArray: "..tostring(newEditConstants))
     local l = #newEditConstants
     for v, cei in pairs(self.editVarMap) do
       local i = cei.index
@@ -1139,7 +1141,7 @@ cassowary.SimplexSolver = subclass(cassowary.Tableau, {
       cassowary:tracePrint(zRow)
       local swCoeff = cn.strength.symbolicWeight.value * cn.weight
       if swCoeff == 0 then
-        cassowary:tracePrint("cn === "..cn.. " swCoeff = 0")
+        cassowary:tracePrint("cn === " .. tostring(cn).. " swCoeff = 0")
       end
       zRow:setVariable(eplus, swCoeff)
       self:noteAddedVariable(eplus, self.objective)


### PR DESCRIPTION
This used to work internally because we had Lua stdlib loaded. It still
works for use cases that either don't trigger trace debugging at the
wrong moment or use stdlib ustream. This should get it working with
traces *and* without stdlib being loaded anywhere.
